### PR TITLE
修复单词拼写错误，升级wechat_assets_picker版本

### DIFF
--- a/lib/business/setting/sheet/theme_setting_sheet.dart
+++ b/lib/business/setting/sheet/theme_setting_sheet.dart
@@ -12,13 +12,21 @@ import 'package:joke_fun_flutter/theme/color_palettes.dart';
 void showThemeSettingBottomSheet() {
   final logic = Get.find<SettingLogic>();
   List<Widget> children = [];
-  children.add(_themeSettingTitle());
   children.addAll(logic.palettesStyles
       .map((element) => _themeSettingItem(element))
       .toList());
   Get.bottomSheet(
       Column(
-        children: children,
+        children: [
+          _themeSettingTitle(),
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                children: children,
+              ),
+            ),
+          )
+        ],
       ),
       backgroundColor: ColorPalettes.instance.background,
       shape: RoundedRectangleBorder(

--- a/lib/business/user_center/edit/avatar/crop_avatar_page.dart
+++ b/lib/business/user_center/edit/avatar/crop_avatar_page.dart
@@ -30,7 +30,7 @@ class CropAvatarPage extends CpnViewState<CropAvatarLogic> {
       shape: CustomCropShape.Square,
       cropPercentage: 0.75,
       canRotate: false,
-      imageFit: CustomImageFit.fillVisiblelWidth,
+      imageFit: CustomImageFit.fillVisibleWidth,
       customProgressIndicator: defaultLoadingWidget(),
       image: FileImage(originImageFile),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,7 +60,7 @@ dependencies:
   # image_gallery_saver https://pub-web.flutter-io.cn/packages/image_gallery_saver/install
   image_gallery_saver: ^2.0.3
   # 微信图片选择器 https://pub-web.flutter-io.cn/packages/wechat_assets_picker/install
-  wechat_assets_picker: ^8.6.3
+  wechat_assets_picker: ^9.5.0
   # image_picker https://pub-web.flutter-io.cn/packages/image_picker/install
   image_picker: ^1.0.2
   # 视频播放器 https://pub-web.flutter-io.cn/packages/chewie/install


### PR DESCRIPTION
1.修复单词拼写错误
2.升级wechat_assets_picker版本，解决依赖photo_manager编译报错Type 'DecoderCallback' not found.